### PR TITLE
tell cider not to inject deps at jack in

### DIFF
--- a/emacs/.emacs.d/personal/custom.el
+++ b/emacs/.emacs.d/personal/custom.el
@@ -15,10 +15,10 @@
    (quote
     (ox-reveal csv-mode git-link key-chord keychord ag with-editor yasnippet aggressive-indent floobits helm-core yaml-mode dockerfile-mode clojure-mode company helm hydra markdown-mode less-css-mode htmlize emmet-mode company-restclient restclient projectile-direnv ace-isearch cljsbuild-mode datomic-snippets clojure-cheatsheet javadoc-lookup clojure-snippets clj-refactor zop-to-char zenburn-theme which-key web-mode volatile-highlights vkill use-package undo-tree unbound smex smartrep smartparens smart-mode-line slime scss-mode rainbow-mode rainbow-identifiers rainbow-delimiters powerline paradox ov operate-on-number multi-term move-text magit json-mode js2-mode inf-ruby indicators imenu-anywhere ido-ubiquitous helm-projectile helm-descbinds helm-ag guru-mode grizzl god-mode gitignore-mode gitconfig-mode git-timemachine git-gutter-fringe+ gist ggtags geiser flycheck flx-ido flatland-theme expand-region exec-path-from-shell ensime elisp-slime-nav easy-kill discover-my-major dired+ diff-hl cyberpunk-theme crux company-anaconda cider browse-kill-ring beacon anzu ack ace-window)))
  '(paradox-github-token t)
+ '(cider-inject-dependencies-at-jack-in nil)
  '(safe-local-variable-values
    (quote
-    ((cider-inject-dependencies-at-jack-in)
-     (cider-cljs-lein-repl . "(do (use 'figwheel-sidecar.repl-api) (start-figwheel!) (cljs-repl))")
+    ((cider-cljs-lein-repl . "(do (use 'figwheel-sidecar.repl-api) (start-figwheel!) (cljs-repl))")
      (projectile-project-type . lein-test))))
  '(vc-annotate-background "#2B2B2B")
  '(vc-annotate-color-map


### PR DESCRIPTION
cider-0.15.1 injects deps on cider-nrepl-0.15.1 and org.clojure/tools-nrepl-0.2.12, but
cider-nrepl-0.15.1 actually depends on org.clojure/tools-nrepl-0.2.13. If you're running
leiningen w/ pedantic? set, this conflict reveals itself.

To get around, just add cider-nrepl-0.15.1 as a plugin in the :repl profile and you're
good to go.